### PR TITLE
Fix for certstore in windows and added proxy support under ureq

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
 tracing-appender = "0.2.3"
 rolling-file = "0.2.0"
+rustls = { version = "0.23.13" }
+rustls-platform-verifier = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.7.0"


### PR DESCRIPTION
### Proposed changes

* Added better support for windows certificates leveraging the rustls-platform-verifier crate
* Added capabilities of pulling proxy from env var

### Related issues

* #17 

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

### Further comments

Using this solution provides support across several cert stores for several OS. This will provide flexibility to the OpenBAS agent. Attempting to strictly use ureq and rustls causes replicated issues and lack of support for Windows.