### PR TITLE
[agent] Adding service user and session user macos installer/upgrade scripts 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,10 @@ jobs:
             curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./target/release/openbas-agent "https://filigran.jfrog.io/artifactory/openbas-agent/macos/arm64/openbas-agent-$version"
             curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/macos/agent-installer.sh "https://filigran.jfrog.io/artifactory/openbas-agent/macos/openbas-agent-installer-$version.sh"
             curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/macos/agent-upgrade.sh "https://filigran.jfrog.io/artifactory/openbas-agent/macos/openbas-agent-upgrade-$version.sh"
+            curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/macos/agent-installer-session-user.sh "https://filigran.jfrog.io/artifactory/openbas-agent/macos/openbas-agent-installer-session-user-$version.sh"
+            curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/macos/agent-upgrade-session-user.sh "https://filigran.jfrog.io/artifactory/openbas-agent/macos/openbas-agent-upgrade-session-user-$version.sh"
+            curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/macos/agent-installer-service-user.sh "https://filigran.jfrog.io/artifactory/openbas-agent/macos/openbas-agent-installer-service-user-$version.sh"
+            curl -usamuel.hassine@filigran.io:$JFROG_TOKEN -T ./installer/macos/agent-upgrade-service-user.sh "https://filigran.jfrog.io/artifactory/openbas-agent/macos/openbas-agent-upgrade-service-user-$version.sh"
       - save_cache:
           key: cargo-{{ arch }}-{{ checksum "Cargo.toml" }}
           paths:

--- a/installer/linux/agent-installer-service-user.sh
+++ b/installer/linux/agent-installer-service-user.sh
@@ -30,7 +30,7 @@ if [ -z "$USER_ARG" ]; then
 fi
 
 if [ -z "$GROUP_ARG" ]; then
-  echo "Error: --group argument is required and cannot be empty."
+  echo "Error: --group argument is required and cannot be empty. You can find your groups with the command 'id'."
   exit 1
 fi
 
@@ -42,7 +42,7 @@ fi
 
 # --- Verify that the group exists ---
 if ! getent group "$GROUP_ARG" >/dev/null 2>&1; then
-  echo "Error: Group '$GROUP_ARG' does not exist. You can find your groups with the command 'id'"
+  echo "Error: Group '$GROUP_ARG' does not exist. You can find your groups with the command 'id'."
   exit 1
 fi
 

--- a/installer/linux/agent-installer-service-user.sh
+++ b/installer/linux/agent-installer-service-user.sh
@@ -68,7 +68,7 @@ fi
 
 echo "Starting install script for ${os} | ${architecture}"
 
-echo "01. Stopping existing openbas-agent-${user}..."
+echo "01. Stopping existing ${service_name}..."
 systemctl stop ${service_name} || echo "Fail stopping ${service_name}"
 
 echo "02. Downloading OpenBAS Agent into ${install_dir}..."

--- a/installer/linux/agent-installer-session-user.sh
+++ b/installer/linux/agent-installer-session-user.sh
@@ -6,7 +6,7 @@ architecture=$(uname -m)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 install_dir="$HOME/.local/openbas-agent-session"
-service_name="openbas-agent-session"
+session_name="openbas-agent-session"
 
 if [ "${os}" != "linux" ]; then
   echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
@@ -20,8 +20,8 @@ fi
 
 echo "Starting install script for ${os} | ${architecture}"
 
-echo "01. Stopping existing openbas-agent-session..."
-systemctl --user stop ${service_name} || echo "Fail stopping ${service_name}"
+echo "01. Stopping existing ${session_name}..."
+systemctl --user stop ${session_name} || echo "Fail stopping ${session_name}"
 
 echo "02. Downloading OpenBAS Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ${install_dir}\n" >&2 && exit 1)
@@ -40,7 +40,7 @@ with_proxy = "${OPENBAS_WITH_PROXY}"
 EOF
 
 echo "04. Writing agent service"
-cat > ${install_dir}/${service_name}.service <<EOF
+cat > ${install_dir}/${session_name}.service <<EOF
 [Unit]
 Description=OpenBAS Agent Session
 After=network.target
@@ -54,10 +54,10 @@ EOF
 
 echo "05. Starting agent service"
 (
-  ln -sf ${install_dir}/${service_name}.service $HOME/.config/systemd/user/
+  ln -sf ${install_dir}/${session_name}.service $HOME/.config/systemd/user/
   systemctl --user daemon-reload
-  systemctl --user enable ${service_name}
-  systemctl --user start ${service_name}
+  systemctl --user enable ${session_name}
+  systemctl --user start ${session_name}
 ) || (echo "Error while enabling OpenBAS Agent systemd unit file or starting the agent" >&2 && exit 1)
 
 echo "OpenBAS Agent started."

--- a/installer/linux/agent-upgrade-session-user.sh
+++ b/installer/linux/agent-upgrade-session-user.sh
@@ -6,7 +6,7 @@ architecture=$(uname -m)
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 install_dir="$HOME/.local/openbas-agent-session"
-service_name="openbas-agent-session"
+session_name="openbas-agent-session"
 
 
 if [ "${os}" != "linux" ]; then
@@ -38,6 +38,6 @@ with_proxy = "${OPENBAS_WITH_PROXY}"
 EOF
 
 echo "03. Restarting the service"
-systemctl --user restart ${service_name} || (echo "Fail restarting ${service_name}" >&2 && exit 1)
+systemctl --user restart ${session_name} || (echo "Fail restarting ${session_name}" >&2 && exit 1)
 
 echo "OpenBAS Agent Session User started."

--- a/installer/macos/agent-installer-service-user.sh
+++ b/installer/macos/agent-installer-service-user.sh
@@ -130,7 +130,7 @@ EOF
     launchctl enable system/${user}.openbas.agent
     launchctl bootstrap system/ ~/Library/LaunchDaemons/${user}-openbas-agent.plist
 
-    echo "OpenBAS Agent started."
+    echo "OpenBAS Agent Service User started."
 else
     echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
     exit 1

--- a/installer/macos/agent-installer-service-user.sh
+++ b/installer/macos/agent-installer-service-user.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+set -e
+
+# --- Parse command-line arguments ---
+USER_ARG=""
+GROUP_ARG=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --user)
+      shift
+      USER_ARG="$1"
+      ;;
+    --group)
+      shift
+      GROUP_ARG="$1"
+      ;;
+    *)
+      echo "Usage: $0 --user [user] --group [group]"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# --- Validate that user and group are provided ---
+if [ -z "$USER_ARG" ]; then
+  echo "Error: --user argument is required and cannot be empty."
+  exit 1
+fi
+
+if [ -z "$GROUP_ARG" ]; then
+  echo "Error: --group argument is required and cannot be empty."
+  exit 1
+fi
+
+# --- Verify that the user exists ---
+if ! id "$USER_ARG" >/dev/null 2>&1; then
+  echo "Error: User '$USER_ARG' does not exist."
+  exit 1
+fi
+
+# --- Verify that the group exists ---
+if ! dscl . read /Groups/"$GROUP_ARG" >/dev/null 2>&1; then
+  echo "Error: Group '$GROUP_ARG' does not exist."
+  exit 1
+fi
+
+base_url=${OPENBAS_URL}
+architecture=$(uname -m)
+user="$USER_ARG"
+group="$GROUP_ARG"
+
+os=$(uname | tr '[:upper:]' '[:lower:]')
+if [ "${os}" = "darwin" ]; then
+  os="macos"
+fi
+
+if [ "${os}" = "macos" ]; then
+    echo "Starting install script for ${os} | ${architecture}"
+
+    echo "01. Stopping existing ${user}.openbas.agent..."
+    launchctl bootout system/ ~/Library/LaunchDaemons/${user}-openbas-agent.plist || echo "openbas-agent already stopped"
+
+    echo "02. Downloading OpenBAS Agent into /opt/openbas-agent-service-${user}..."
+    (mkdir -p /opt/openbas-agent-service-${user} && touch /opt/openbas-agent-service-${user} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
+    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o /opt/openbas-agent-service-${user}/openbas-agent
+    chmod +x /opt/openbas-agent-service-${user}/openbas-agent
+
+    echo "03. Creating OpenBAS configuration file"
+    cat > /opt/penbas-agent-service-${user}/openbas-agent-config.toml <<EOF
+debug=false
+
+[openbas]
+url = "${OPENBAS_URL}"
+token = "${OPENBAS_TOKEN}"
+unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
+with_proxy = "${OPENBAS_WITH_PROXY}"
+EOF
+
+    echo "04. Writing agent service"
+    mkdir -p ~/Library/LaunchDaemons
+    cat > ~/Library/LaunchDaemons/${user}-openbas-agent.plist <<EOF
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>${user}.openbas.agent</string>
+
+            <key>Program</key>
+            <string>/opt/openbas-agent-service-${user}/openbas-agent</string>
+
+            <key>RunAtLoad</key>
+            <true/>
+
+            <!-- The agent needs to run at all times -->
+            <key>KeepAlive</key>
+            <true/>
+
+            <!-- This prevents macOS from limiting the resource usage of the agent -->
+            <key>ProcessType</key>
+            <string>Interactive</string>
+
+            <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+            <key>ThrottleInterval</key>
+            <integer>60</integer>
+
+            <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+            <key>ExitTimeOut</key>
+            <integer>600</integer>
+
+            <key>StandardOutPath</key>
+            <string>/opt/openbas-agent-service-${user}/runner.log</string>
+            <key>StandardErrorPath</key>
+            <string>/opt/openbas-agent-service-${user}/runner.log</string>
+
+            <key>UserName</key>
+            <string>${user}</string>
+            <key>GroupName</key>
+            <string>${group}</string>
+            <key>InitGroups</key>
+            <true/>
+        </dict>
+    </plist>
+EOF
+
+    chown -R ${user}:${group} /opt/openbas-agent-service-${user}
+    echo "05. Starting agent service"
+    launchctl enable system/${user}.openbas.agent
+    launchctl bootstrap system/ ~/Library/LaunchDaemons/${user}-openbas-agent.plist
+
+    echo "OpenBAS Agent started."
+else
+    echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
+    exit 1
+fi

--- a/installer/macos/agent-installer-service-user.sh
+++ b/installer/macos/agent-installer-service-user.sh
@@ -42,7 +42,7 @@ fi
 
 # --- Verify that the group exists ---
 if ! dscl . read /Groups/"$GROUP_ARG" >/dev/null 2>&1; then
-  echo "Error: Group '$GROUP_ARG' does not exist."
+  echo "Error: Group '$GROUP_ARG' does not exist. You can find your groups with the command 'id'""
   exit 1
 fi
 
@@ -51,24 +51,31 @@ architecture=$(uname -m)
 user="$USER_ARG"
 group="$GROUP_ARG"
 
+install_dir="/opt/openbas-agent-service-${user}"
+service_name="${user}-openbas-agent"
+
 os=$(uname | tr '[:upper:]' '[:lower:]')
 if [ "${os}" = "darwin" ]; then
   os="macos"
 fi
 
-if [ "${os}" = "macos" ]; then
-    echo "Starting install script for ${os} | ${architecture}"
+if [ "${os}" != "macos" ]; then
+  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
+  exit 1
+fi
 
-    echo "01. Stopping existing ${user}.openbas.agent..."
-    launchctl bootout system/ ~/Library/LaunchDaemons/${user}-openbas-agent.plist || echo "openbas-agent already stopped"
+echo "Starting install script for ${os} | ${architecture}"
 
-    echo "02. Downloading OpenBAS Agent into /opt/openbas-agent-service-${user}..."
-    (mkdir -p /opt/openbas-agent-service-${user} && touch /opt/openbas-agent-service-${user} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
-    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o /opt/openbas-agent-service-${user}/openbas-agent
-    chmod +x /opt/openbas-agent-service-${user}/openbas-agent
+echo "01. Stopping existing ${user}.openbas.agent..."
+launchctl bootout system/ ~/Library/LaunchDaemons/${service_name}.plist || echo "openbas-agent already stopped"
 
-    echo "03. Creating OpenBAS configuration file"
-    cat > /opt/openbas-agent-service-${user}/openbas-agent-config.toml <<EOF
+echo "02. Downloading OpenBAS Agent into ${install_dir}..."
+(mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
+curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ${install_dir}/openbas-agent
+chmod +x ${install_dir}/openbas-agent
+
+echo "03. Creating OpenBAS configuration file"
+cat > ${install_dir}/openbas-agent-config.toml <<EOF
 debug=false
 
 [openbas]
@@ -78,60 +85,56 @@ unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
 with_proxy = "${OPENBAS_WITH_PROXY}"
 EOF
 
-    echo "04. Writing agent service"
-    mkdir -p ~/Library/LaunchDaemons
-    cat > ~/Library/LaunchDaemons/${user}-openbas-agent.plist <<EOF
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-        <dict>
-            <key>Label</key>
-            <string>${user}.openbas.agent</string>
+echo "04. Writing agent service"
+mkdir -p ~/Library/LaunchDaemons
+cat > ~/Library/LaunchDaemons/${service_name}.plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>${user}.openbas.agent</string>
 
-            <key>Program</key>
-            <string>/opt/openbas-agent-service-${user}/openbas-agent</string>
+        <key>Program</key>
+        <string>${install_dir}/openbas-agent</string>
 
-            <key>RunAtLoad</key>
-            <true/>
+        <key>RunAtLoad</key>
+        <true/>
 
-            <!-- The agent needs to run at all times -->
-            <key>KeepAlive</key>
-            <true/>
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
 
-            <!-- This prevents macOS from limiting the resource usage of the agent -->
-            <key>ProcessType</key>
-            <string>Interactive</string>
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
 
-            <!-- Increase the frequency of restarting the agent on failure, or post-update -->
-            <key>ThrottleInterval</key>
-            <integer>60</integer>
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>60</integer>
 
-            <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
-            <key>ExitTimeOut</key>
-            <integer>600</integer>
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
 
-            <key>StandardOutPath</key>
-            <string>/opt/openbas-agent-service-${user}/runner.log</string>
-            <key>StandardErrorPath</key>
-            <string>/opt/openbas-agent-service-${user}/runner.log</string>
+        <key>StandardOutPath</key>
+        <string>${install_dir}/runner.log</string>
+        <key>StandardErrorPath</key>
+        <string>${install_dir}/runner.log</string>
 
-            <key>UserName</key>
-            <string>${user}</string>
-            <key>GroupName</key>
-            <string>${group}</string>
-            <key>InitGroups</key>
-            <true/>
-        </dict>
-    </plist>
+        <key>UserName</key>
+        <string>${user}</string>
+        <key>GroupName</key>
+        <string>${group}</string>
+        <key>InitGroups</key>
+        <true/>
+    </dict>
+</plist>
 EOF
 
-    chown -R ${user}:${group} /opt/openbas-agent-service-${user}
-    echo "05. Starting agent service"
-    launchctl enable system/${user}.openbas.agent
-    launchctl bootstrap system/ ~/Library/LaunchDaemons/${user}-openbas-agent.plist
+chown -R ${user}:${group} ${install_dir}
+echo "05. Starting agent service"
+launchctl enable system/${user}.openbas.agent
+launchctl bootstrap system/ ~/Library/LaunchDaemons/${service_name}.plist
 
-    echo "OpenBAS Agent Service User started."
-else
-    echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
-    exit 1
-fi
+echo "OpenBAS Agent Service User started."

--- a/installer/macos/agent-installer-service-user.sh
+++ b/installer/macos/agent-installer-service-user.sh
@@ -30,7 +30,7 @@ if [ -z "$USER_ARG" ]; then
 fi
 
 if [ -z "$GROUP_ARG" ]; then
-  echo "Error: --group argument is required and cannot be empty."
+  echo "Error: --group argument is required and cannot be empty. You can find your groups with the command 'id'."
   exit 1
 fi
 
@@ -42,7 +42,7 @@ fi
 
 # --- Verify that the group exists ---
 if ! dscl . read /Groups/"$GROUP_ARG" >/dev/null 2>&1; then
-  echo "Error: Group '$GROUP_ARG' does not exist. You can find your groups with the command 'id'""
+  echo "Error: Group '$GROUP_ARG' does not exist. You can find your groups with the command 'id'."
   exit 1
 fi
 

--- a/installer/macos/agent-installer-service-user.sh
+++ b/installer/macos/agent-installer-service-user.sh
@@ -66,8 +66,8 @@ fi
 
 echo "Starting install script for ${os} | ${architecture}"
 
-echo "01. Stopping existing ${user}.openbas.agent..."
-launchctl bootout system/ ~/Library/LaunchDaemons/${service_name}.plist || echo "openbas-agent already stopped"
+echo "01. Stopping existing ${service_name}..."
+launchctl bootout system/ ~/Library/LaunchDaemons/${service_name}.plist || echo "${service_name} already stopped"
 
 echo "02. Downloading OpenBAS Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
@@ -93,7 +93,7 @@ cat > ~/Library/LaunchDaemons/${service_name}.plist <<EOF
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>${user}.openbas.agent</string>
+        <string>${service_name}</string>
 
         <key>Program</key>
         <string>${install_dir}/openbas-agent</string>
@@ -134,7 +134,7 @@ EOF
 
 chown -R ${user}:${group} ${install_dir}
 echo "05. Starting agent service"
-launchctl enable system/${user}.openbas.agent
+launchctl enable system/${service_name}
 launchctl bootstrap system/ ~/Library/LaunchDaemons/${service_name}.plist
 
 echo "OpenBAS Agent Service User started."

--- a/installer/macos/agent-installer-service-user.sh
+++ b/installer/macos/agent-installer-service-user.sh
@@ -68,7 +68,7 @@ if [ "${os}" = "macos" ]; then
     chmod +x /opt/openbas-agent-service-${user}/openbas-agent
 
     echo "03. Creating OpenBAS configuration file"
-    cat > /opt/penbas-agent-service-${user}/openbas-agent-config.toml <<EOF
+    cat > /opt/openbas-agent-service-${user}/openbas-agent-config.toml <<EOF
 debug=false
 
 [openbas]

--- a/installer/macos/agent-installer-session-user.sh
+++ b/installer/macos/agent-installer-session-user.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+set -e
+
+base_url=${OPENBAS_URL}
+architecture=$(uname -m)
+
+os=$(uname | tr '[:upper:]' '[:lower:]')
+if [ "${os}" = "darwin" ]; then
+  os="macos"
+fi
+
+if [ "${os}" = "macos" ]; then
+    echo "Starting install script for ${os} | ${architecture}"
+
+    echo "01. Stopping existing openbas-agent-session..."
+    launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/openbas-agent-session.plist || echo "openbas-agent already stopped"
+
+    echo "02. Downloading OpenBAS Agent into ~/.local/openbas-agent-session..."
+    (mkdir -p ~/.local/openbas-agent-session && touch ~/.local/openbas-agent-session >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ~/.local\n" >&2 && exit 1)
+    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ~/.local/openbas-agent-session/openbas-agent
+    chmod +x ~/.local/openbas-agent-session/openbas-agent
+
+    echo "03. Creating OpenBAS configuration file"
+    cat > ~/.local/openbas-agent-session/openbas-agent-config.toml <<EOF
+debug=false
+
+[openbas]
+url = "${OPENBAS_URL}"
+token = "${OPENBAS_TOKEN}"
+unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
+with_proxy = "${OPENBAS_WITH_PROXY}"
+EOF
+
+    echo "04. Writing agent service"
+    mkdir -p ~/Library/LaunchAgents
+    cat > ~/Library/LaunchAgents/openbas-agent-session.plist <<EOF
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>openbas.agent.session</string>
+
+            <key>Program</key>
+            <string>/Users/$(id -un)/.local/openbas-agent-session/openbas-agent</string>
+
+            <key>RunAtLoad</key>
+            <true/>
+
+            <!-- The agent needs to run at all times -->
+            <key>KeepAlive</key>
+            <true/>
+
+            <!-- This prevents macOS from limiting the resource usage of the agent -->
+            <key>ProcessType</key>
+            <string>Interactive</string>
+
+            <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+            <key>ThrottleInterval</key>
+            <integer>60</integer>
+
+            <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+            <key>ExitTimeOut</key>
+            <integer>600</integer>
+
+            <key>StandardOutPath</key>
+            <string>/Users/$(id -un)/.local/openbas-agent-session/runner.log</string>
+            <key>StandardErrorPath</key>
+            <string>/Users/$(id -un)/.local/openbas-agent-session/runner.log</string>
+        </dict>
+    </plist>
+EOF
+
+    echo "05. Starting agent service"
+    launchctl enable user/$(id -u)/~/Library/LaunchAgents/openbas-agent-session.plist
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/openbas-agent-session.plist
+
+    echo "OpenBAS Agent started."
+else
+    echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
+    exit 1
+fi

--- a/installer/macos/agent-installer-session-user.sh
+++ b/installer/macos/agent-installer-session-user.sh
@@ -15,13 +15,13 @@ if [ "${os}" = "macos" ]; then
     echo "01. Stopping existing openbas-agent-session..."
     launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/openbas-agent-session.plist || echo "openbas-agent already stopped"
 
-    echo "02. Downloading OpenBAS Agent into ~/.local/openbas-agent-session..."
-    (mkdir -p ~/.local/openbas-agent-session && touch ~/.local/openbas-agent-session >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to ~/.local\n" >&2 && exit 1)
-    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ~/.local/openbas-agent-session/openbas-agent
-    chmod +x ~/.local/openbas-agent-session/openbas-agent
+    echo "02. Downloading OpenBAS Agent into $HOME/.local/openbas-agent-session..."
+    (mkdir -p $HOME/.local/openbas-agent-session && touch $HOME/.local/openbas-agent-session >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to $HOME/.local\n" >&2 && exit 1)
+    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o $HOME/.local/openbas-agent-session/openbas-agent
+    chmod +x $HOME/.local/openbas-agent-session/openbas-agent
 
     echo "03. Creating OpenBAS configuration file"
-    cat > ~/.local/openbas-agent-session/openbas-agent-config.toml <<EOF
+    cat > $HOME/.local/openbas-agent-session/openbas-agent-config.toml <<EOF
 debug=false
 
 [openbas]

--- a/installer/macos/agent-installer-session-user.sh
+++ b/installer/macos/agent-installer-session-user.sh
@@ -75,7 +75,7 @@ EOF
     launchctl enable user/$(id -u)/~/Library/LaunchAgents/openbas-agent-session.plist
     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/openbas-agent-session.plist
 
-    echo "OpenBAS Agent started."
+    echo "OpenBAS Agent Session User started."
 else
     echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
     exit 1

--- a/installer/macos/agent-installer-session-user.sh
+++ b/installer/macos/agent-installer-session-user.sh
@@ -4,8 +4,8 @@ set -e
 base_url=${OPENBAS_URL}
 architecture=$(uname -m)
 
-install_dir="$HOME/.local/openbas-agent-session"
-service_name="openbas-agent-session"
+install_dir="/Users/$(id -un)/.local/openbas-agent-session"
+session_name="openbas-agent-session"
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 if [ "${os}" = "darwin" ]; then
@@ -19,8 +19,8 @@ fi
 
 echo "Starting install script for ${os} | ${architecture}"
 
-echo "01. Stopping existing openbas-agent-session..."
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${service_name}.plist || echo "openbas-agent already stopped"
+echo "01. Stopping existing ${session_name}..."
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${session_name}.plist || echo "${session_name} already stopped"
 
 echo "02. Downloading OpenBAS Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to $HOME/.local\n" >&2 && exit 1)
@@ -40,16 +40,16 @@ EOF
 
 echo "04. Writing agent service"
 mkdir -p ~/Library/LaunchAgents
-cat > ~/Library/LaunchAgents/${service_name}.plist <<EOF
+cat > ~/Library/LaunchAgents/${session_name}.plist <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>openbas.agent.session</string>
+        <string>${session_name}</string>
 
         <key>Program</key>
-        <string>/Users/$(id -un)/.local/${service_name}/openbas-agent</string>
+        <string>${install_dir}/openbas-agent</string>
 
         <key>RunAtLoad</key>
         <true/>
@@ -71,15 +71,15 @@ cat > ~/Library/LaunchAgents/${service_name}.plist <<EOF
         <integer>600</integer>
 
         <key>StandardOutPath</key>
-        <string>/Users/$(id -un)/.local/${service_name}/runner.log</string>
+        <string>${install_dir}/runner.log</string>
         <key>StandardErrorPath</key>
-        <string>/Users/$(id -un)/.local/${service_name}/runner.log</string>
+        <string>${install_dir}/runner.log</string>
     </dict>
 </plist>
 EOF
 
 echo "05. Starting agent service"
-launchctl enable user/$(id -u)/~/Library/LaunchAgents/${service_name}.plist
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/${service_name}.plist
+launchctl enable user/$(id -u)/~/Library/LaunchAgents/${session_name}.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/${session_name}.plist
 
 echo "OpenBAS Agent Session User started."

--- a/installer/macos/agent-installer.sh
+++ b/installer/macos/agent-installer.sh
@@ -4,24 +4,31 @@ set -e
 base_url=${OPENBAS_URL}
 architecture=$(uname -m)
 
+install_dir="/opt/openbas-agent"
+service_name="openbas-agent"
+
 os=$(uname | tr '[:upper:]' '[:lower:]')
 if [ "${os}" = "darwin" ]; then
   os="macos"
 fi
 
-if [ "${os}" = "macos" ]; then
-    echo "Starting install script for ${os} | ${architecture}"
+if [ "${os}" != "macos" ]; then
+  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
+  exit 1
+fi
 
-    echo "01. Stopping existing openbas-agent..."
-    launchctl bootout system/ ~/Library/LaunchDaemons/openbas-agent.plist || echo "openbas-agent already stopped"
+echo "Starting install script for ${os} | ${architecture}"
 
-    echo "02. Downloading OpenBAS Agent into /opt/openbas-agent..."
-    (mkdir -p /opt/openbas-agent && touch /opt/openbas-agent >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
-    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o /opt/openbas-agent/openbas-agent
-    chmod 755 /opt/openbas-agent/openbas-agent
+echo "01. Stopping existing openbas-agent..."
+launchctl bootout system/ ~/Library/LaunchDaemons/${service_name}.plist || echo "openbas-agent already stopped"
 
-    echo "03. Creating OpenBAS configuration file"
-    cat > /opt/openbas-agent/openbas-agent-config.toml <<EOF
+echo "02. Downloading OpenBAS Agent into ${install_dir}..."
+(mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
+curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ${install_dir}/openbas-agent
+chmod 755 ${install_dir}/openbas-agent
+
+echo "03. Creating OpenBAS configuration file"
+cat > ${install_dir}/openbas-agent-config.toml <<EOF
 debug=false
 
 [openbas]
@@ -31,52 +38,48 @@ unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
 with_proxy = "${OPENBAS_WITH_PROXY}"
 EOF
 
-    echo "04. Writing agent service"
-    mkdir -p ~/Library/LaunchDaemons
-    cat > ~/Library/LaunchDaemons/openbas-agent.plist <<EOF
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-        <dict>
-            <key>Label</key>
-            <string>openbas.agent</string>
+echo "04. Writing agent service"
+mkdir -p ~/Library/LaunchDaemons
+cat > ~/Library/LaunchDaemons/${service_name}.plist <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>openbas.agent</string>
 
-            <key>Program</key>
-            <string>/opt/openbas-agent/openbas-agent</string>
+        <key>Program</key>
+        <string>${install_dir}/${service_name}</string>
 
-            <key>RunAtLoad</key>
-            <true/>
+        <key>RunAtLoad</key>
+        <true/>
 
-            <!-- The agent needs to run at all times -->
-            <key>KeepAlive</key>
-            <true/>
+        <!-- The agent needs to run at all times -->
+        <key>KeepAlive</key>
+        <true/>
 
-            <!-- This prevents macOS from limiting the resource usage of the agent -->
-            <key>ProcessType</key>
-            <string>Interactive</string>
+        <!-- This prevents macOS from limiting the resource usage of the agent -->
+        <key>ProcessType</key>
+        <string>Interactive</string>
 
-            <!-- Increase the frequency of restarting the agent on failure, or post-update -->
-            <key>ThrottleInterval</key>
-            <integer>60</integer>
+        <!-- Increase the frequency of restarting the agent on failure, or post-update -->
+        <key>ThrottleInterval</key>
+        <integer>60</integer>
 
-            <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
-            <key>ExitTimeOut</key>
-            <integer>600</integer>
+        <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
+        <key>ExitTimeOut</key>
+        <integer>600</integer>
 
-            <key>StandardOutPath</key>
-            <string>/opt/openbas-agent/runner.log</string>
-            <key>StandardErrorPath</key>
-            <string>/opt/openbas-agent/runner.log</string>
-        </dict>
-    </plist>
+        <key>StandardOutPath</key>
+        <string>${install_dir}/runner.log</string>
+        <key>StandardErrorPath</key>
+        <string>${install_dir}/runner.log</string>
+    </dict>
+</plist>
 EOF
 
-    echo "05. Starting agent service"
-    launchctl enable system/openbas.agent
-    launchctl bootstrap system/ ~/Library/LaunchDaemons/openbas-agent.plist
+echo "05. Starting agent service"
+launchctl enable system/openbas.agent
+launchctl bootstrap system/ ~/Library/LaunchDaemons/${service_name}.plist
 
-    echo "OpenBAS Agent started."
-else
-    echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
-    exit 1
-fi
+echo "OpenBAS Agent started."

--- a/installer/macos/agent-installer.sh
+++ b/installer/macos/agent-installer.sh
@@ -19,8 +19,8 @@ fi
 
 echo "Starting install script for ${os} | ${architecture}"
 
-echo "01. Stopping existing openbas-agent..."
-launchctl bootout system/ ~/Library/LaunchDaemons/${service_name}.plist || echo "openbas-agent already stopped"
+echo "01. Stopping existing ${service_name}..."
+launchctl bootout system/ ~/Library/LaunchDaemons/${service_name}.plist || echo "${service_name} already stopped"
 
 echo "02. Downloading OpenBAS Agent into ${install_dir}..."
 (mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)

--- a/installer/macos/agent-installer.sh
+++ b/installer/macos/agent-installer.sh
@@ -57,7 +57,7 @@ EOF
 
             <!-- Increase the frequency of restarting the agent on failure, or post-update -->
             <key>ThrottleInterval</key>
-            <integer>3</integer>
+            <integer>60</integer>
 
             <!-- Wait for 10 minutes for the agent to shut down (the agent itself waits for tasks to complete) -->
             <key>ExitTimeOut</key>

--- a/installer/macos/agent-upgrade-service-user.sh
+++ b/installer/macos/agent-upgrade-service-user.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+
+base_url=${OPENBAS_URL}
+architecture=$(uname -m)
+user="$(id -un)"
+group="$(id -gn)"
+
+os=$(uname | tr '[:upper:]' '[:lower:]')
+if [ "${os}" = "darwin" ]; then
+  os="macos"
+fi
+
+if [ "${os}" = "macos" ]; then
+    echo "Starting upgrade script for ${os} | ${architecture}"
+
+    echo "01. Downloading OpenBAS Agent into /opt/openbas-agent-service-${user}..."
+    (mkdir -p /opt/openbas-agent-service-${user} && touch /opt/openbas-agent-service-${user} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
+    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o /opt/openbas-agent-service-${user}/openbas-agent_upgrade
+    mv /opt/openbas-agent-service-${user}/openbas-agent_upgrade /opt/openbas-agent-service-${user}/openbas-agent
+    chmod +x /opt/openbas-agent-service-${user}/openbas-agent
+
+    echo "02. Updating OpenBAS configuration file"
+    cat > /opt/openbas-agent-service-${user}/openbas-agent-config.toml <<EOF
+debug=false
+
+[openbas]
+url = "${OPENBAS_URL}"
+token = "${OPENBAS_TOKEN}"
+unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
+with_proxy = "${OPENBAS_WITH_PROXY}"
+EOF
+
+    echo "03. Kill the process of the existing service"
+    (pkill -9 -f "/opt/openbas-agent-service-${user}/openbas-agent") || (echo "Error while killing the process of the openbas agent service" >&2 && exit 1)
+    echo "The OpenBAS agent process was stopped, the service will automatically restart in 60 seconds"
+else
+    echo "Operating system ${os} is not supported yet, please create a ticket in openbas github project"
+    exit 1
+fi

--- a/installer/macos/agent-upgrade-service-user.sh
+++ b/installer/macos/agent-upgrade-service-user.sh
@@ -6,22 +6,28 @@ architecture=$(uname -m)
 user="$(id -un)"
 group="$(id -gn)"
 
+install_dir="/opt/openbas-agent-service-${user}"
+
 os=$(uname | tr '[:upper:]' '[:lower:]')
 if [ "${os}" = "darwin" ]; then
   os="macos"
 fi
 
-if [ "${os}" = "macos" ]; then
-    echo "Starting upgrade script for ${os} | ${architecture}"
+if [ "${os}" != "macos" ]; then
+  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
+  exit 1
+fi
 
-    echo "01. Downloading OpenBAS Agent into /opt/openbas-agent-service-${user}..."
-    (mkdir -p /opt/openbas-agent-service-${user} && touch /opt/openbas-agent-service-${user} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
-    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o /opt/openbas-agent-service-${user}/openbas-agent_upgrade
-    mv /opt/openbas-agent-service-${user}/openbas-agent_upgrade /opt/openbas-agent-service-${user}/openbas-agent
-    chmod +x /opt/openbas-agent-service-${user}/openbas-agent
+echo "Starting upgrade script for ${os} | ${architecture}"
 
-    echo "02. Updating OpenBAS configuration file"
-    cat > /opt/openbas-agent-service-${user}/openbas-agent-config.toml <<EOF
+echo "01. Downloading OpenBAS Agent into ${install_dir}..."
+(mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
+curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ${install_dir}/openbas-agent_upgrade
+mv ${install_dir}/openbas-agent_upgrade ${install_dir}/openbas-agent
+chmod +x ${install_dir}/openbas-agent
+
+echo "02. Updating OpenBAS configuration file"
+cat > ${install_dir}/openbas-agent-config.toml <<EOF
 debug=false
 
 [openbas]
@@ -31,10 +37,6 @@ unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
 with_proxy = "${OPENBAS_WITH_PROXY}"
 EOF
 
-    echo "03. Kill the process of the existing service"
-    (pkill -9 -f "/opt/openbas-agent-service-${user}/openbas-agent") || (echo "Error while killing the process of the openbas agent service" >&2 && exit 1)
-    echo "The OpenBAS agent process was stopped, the service will automatically restart in 60 seconds"
-else
-    echo "Operating system ${os} is not supported yet, please create a ticket in openbas github project"
-    exit 1
-fi
+echo "03. Kill the process of the existing service"
+(pkill -9 -f "${install_dir}/openbas-agent") || (echo "Error while killing the process of the openbas agent service" >&2 && exit 1)
+echo "The OpenBAS agent process was stopped, the service will automatically restart in 60 seconds"

--- a/installer/macos/agent-upgrade-session-user.sh
+++ b/installer/macos/agent-upgrade-session-user.sh
@@ -4,21 +4,28 @@ set -e
 base_url=${OPENBAS_URL}
 architecture=$(uname -m)
 
+install_dir="$HOME/.local/openbas-agent-session"
+service_name="openbas-agent-session"
+
 os=$(uname | tr '[:upper:]' '[:lower:]')
 if [ "${os}" = "darwin" ]; then
   os="macos"
 fi
 
-if [ "${os}" = "macos" ]; then
-    echo "Starting upgrade script for ${os} | ${architecture}"
+if [ "${os}" != "macos" ]; then
+  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
+  exit 1
+fi
 
-    echo "01. Downloading OpenBAS Agent into $HOME/.local/openbas-agent-session..."
-    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o $HOME/.local/openbas-agent-session/openbas-agent_upgrade
-    mv $HOME/.local/openbas-agent-session/openbas-agent_upgrade $HOME/.local/openbas-agent-session/openbas-agent
-    chmod +x $HOME/.local/openbas-agent-session/openbas-agent
+echo "Starting upgrade script for ${os} | ${architecture}"
 
-    echo "02. Updating OpenBAS configuration file"
-    cat > $HOME/.local/openbas-agent-session/openbas-agent-config.toml <<EOF
+echo "01. Downloading OpenBAS Agent into ${install_dir}..."
+curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ${install_dir}/openbas-agent_upgrade
+mv ${install_dir}/openbas-agent_upgrade ${install_dir}/openbas-agent
+chmod +x ${install_dir}/openbas-agent
+
+echo "02. Updating OpenBAS configuration file"
+cat > ${install_dir}/openbas-agent-config.toml <<EOF
 debug=false
 
 [openbas]
@@ -28,12 +35,8 @@ unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
 with_proxy = "${OPENBAS_WITH_PROXY}"
 EOF
 
-    echo "03. Starting agent service"
-    launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/openbas-agent-session.plist || echo "openbas-agent already stopped"
-    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/openbas-agent-session.plist
+echo "03. Starting agent service"
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${service_name}.plist || (echo "Fail restarting ${service_name}" >&2 && exit 1)
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/${service_name}.plist
 
-    echo "OpenBAS Agent Session User started."
-else
-    echo "Operating system ${os} is not supported yet, please create a ticket in openbas github project"
-    exit 1
-fi
+echo "OpenBAS Agent Session User started."

--- a/installer/macos/agent-upgrade-session-user.sh
+++ b/installer/macos/agent-upgrade-session-user.sh
@@ -5,7 +5,7 @@ base_url=${OPENBAS_URL}
 architecture=$(uname -m)
 
 install_dir="$HOME/.local/openbas-agent-session"
-service_name="openbas-agent-session"
+session_name="openbas-agent-session"
 
 os=$(uname | tr '[:upper:]' '[:lower:]')
 if [ "${os}" = "darwin" ]; then
@@ -36,7 +36,7 @@ with_proxy = "${OPENBAS_WITH_PROXY}"
 EOF
 
 echo "03. Starting agent service"
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${service_name}.plist || (echo "Fail restarting ${service_name}" >&2 && exit 1)
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/${service_name}.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/${session_name}.plist || (echo "Fail restarting ${session_name}" >&2 && exit 1)
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/${session_name}.plist
 
 echo "OpenBAS Agent Session User started."

--- a/installer/macos/agent-upgrade-session-user.sh
+++ b/installer/macos/agent-upgrade-session-user.sh
@@ -12,13 +12,13 @@ fi
 if [ "${os}" = "macos" ]; then
     echo "Starting upgrade script for ${os} | ${architecture}"
 
-    echo "01. Downloading OpenBAS Agent into ~/.local/openbas-agent-session..."
-    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ~/.local/openbas-agent-session/openbas-agent_upgrade
-    mv ~/.local/openbas-agent-session/openbas-agent_upgrade ~/.local/openbas-agent-session/openbas-agent
-    chmod +x ~/.local/openbas-agent-session/openbas-agent
+    echo "01. Downloading OpenBAS Agent into $HOME/.local/openbas-agent-session..."
+    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o $HOME/.local/openbas-agent-session/openbas-agent_upgrade
+    mv $HOME/.local/openbas-agent-session/openbas-agent_upgrade $HOME/.local/openbas-agent-session/openbas-agent
+    chmod +x $HOME/.local/openbas-agent-session/openbas-agent
 
     echo "02. Updating OpenBAS configuration file"
-    cat > ~/.local/openbas-agent-session/openbas-agent-config.toml <<EOF
+    cat > $HOME/.local/openbas-agent-session/openbas-agent-config.toml <<EOF
 debug=false
 
 [openbas]

--- a/installer/macos/agent-upgrade-session-user.sh
+++ b/installer/macos/agent-upgrade-session-user.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -e
+
+base_url=${OPENBAS_URL}
+architecture=$(uname -m)
+
+os=$(uname | tr '[:upper:]' '[:lower:]')
+if [ "${os}" = "darwin" ]; then
+  os="macos"
+fi
+
+if [ "${os}" = "macos" ]; then
+    echo "Starting upgrade script for ${os} | ${architecture}"
+
+    echo "01. Downloading OpenBAS Agent into ~/.local/openbas-agent-session..."
+    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ~/.local/openbas-agent-session/openbas-agent_upgrade
+    mv ~/.local/openbas-agent-session/openbas-agent_upgrade ~/.local/openbas-agent-session/openbas-agent
+    chmod +x ~/.local/openbas-agent-session/openbas-agent
+
+    echo "02. Updating OpenBAS configuration file"
+    cat > ~/.local/openbas-agent-session/openbas-agent-config.toml <<EOF
+debug=false
+
+[openbas]
+url = "${OPENBAS_URL}"
+token = "${OPENBAS_TOKEN}"
+unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
+with_proxy = "${OPENBAS_WITH_PROXY}"
+EOF
+
+    echo "03. Starting agent service"
+    launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/openbas-agent-session.plist || echo "openbas-agent already stopped"
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/openbas-agent-session.plist
+
+    echo "OpenBAS Agent Session User started."
+else
+    echo "Operating system ${os} is not supported yet, please create a ticket in openbas github project"
+    exit 1
+fi

--- a/installer/macos/agent-upgrade.sh
+++ b/installer/macos/agent-upgrade.sh
@@ -4,22 +4,29 @@ set -e
 base_url=${OPENBAS_URL}
 architecture=$(uname -m)
 
+install_dir="/opt/openbas-agent"
+service_name="openbas-agent"
+
 os=$(uname | tr '[:upper:]' '[:lower:]')
 if [ "${os}" = "darwin" ]; then
   os="macos"
 fi
 
-if [ "${os}" = "macos" ]; then
-    echo "Starting upgrade script for ${os} | ${architecture}"
+if [ "${os}" != "macos" ]; then
+  echo "Operating system $OSTYPE is not supported yet, please create a ticket in openbas github project"
+  exit 1
+fi
 
-    echo "01. Downloading OpenBAS Agent into /opt/openbas-agent..."
-    (mkdir -p /opt/openbas-agent && touch /opt/openbas-agent >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
-    curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o /opt/openbas-agent/openbas-agent_upgrade
-    mv /opt/openbas-agent/openbas-agent_upgrade /opt/openbas-agent/openbas-agent
-    chmod 755 /opt/openbas-agent/openbas-agent
+echo "Starting upgrade script for ${os} | ${architecture}"
 
-    echo "02. Updating OpenBAS configuration file"
-    cat > /opt/openbas-agent/openbas-agent-config.toml <<EOF
+echo "01. Downloading OpenBAS Agent into ${install_dir}..."
+(mkdir -p ${install_dir} && touch ${install_dir} >/dev/null 2>&1) || (echo -n "\nFatal: Can't write to /opt\n" >&2 && exit 1)
+curl -sSfL ${base_url}/api/agent/executable/openbas/${os}/${architecture} -o ${install_dir}/openbas-agent_upgrade
+mv ${install_dir}/openbas-agent_upgrade ${install_dir}/openbas-agent
+chmod 755 ${install_dir}/openbas-agent
+
+echo "02. Updating OpenBAS configuration file"
+cat > ${install_dir}/openbas-agent-config.toml <<EOF
 debug=false
 
 [openbas]
@@ -29,12 +36,8 @@ unsecured_certificate = "${OPENBAS_UNSECURED_CERTIFICATE}"
 with_proxy = "${OPENBAS_WITH_PROXY}"
 EOF
 
-    echo "03. Starting agent service"
-    launchctl bootout system/ ~/Library/LaunchDaemons/openbas-agent.plist || echo "openbas-agent already stopped"
-    launchctl bootstrap system/ ~/Library/LaunchDaemons/openbas-agent.plist
+echo "03. Starting agent service"
+launchctl bootout system/ ~/Library/LaunchDaemons/${service_name}.plist || echo "openbas-agent already stopped"
+launchctl bootstrap system/ ~/Library/LaunchDaemons/${service_name}.plist
 
-    echo "OpenBAS Agent started."
-else
-    echo "Operating system ${os} is not supported yet, please create a ticket in openbas github project"
-    exit 1
-fi
+echo "OpenBAS Agent started."

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -114,8 +114,11 @@ impl ExecutionDetails {
         } else {
             let is_elevated_output = Self::invoke_command(executor, "id", args.as_slice());
             let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
-            let is_service_output =
-                Self::invoke_command(executor, "launchctl print gui/$(id -u)/openbas.agent.session", args.as_slice());
+            let is_service_output = Self::invoke_command(
+                executor,
+                "launchctl print gui/$(id -u)/openbas.agent.session",
+                args.as_slice(),
+            );
             let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);
             Ok(ExecutionDetails {
                 is_elevated: is_elevated.contains("(admin)"),

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -116,13 +116,13 @@ impl ExecutionDetails {
             let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
             let is_service_output = Self::invoke_command(
                 executor,
-                "launchctl print gui/$(id -u)/openbas.agent.session",
+                "launchctl print gui/$(id -u)/openbas-agent-session",
                 args.as_slice(),
             );
             let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);
             Ok(ExecutionDetails {
                 is_elevated: is_elevated.contains("(admin)"),
-                is_service: !is_service.contains("openbas.agent.session"),
+                is_service: !is_service.contains("openbas-agent-session"),
                 executed_by_user: user,
             })
         }

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -115,11 +115,11 @@ impl ExecutionDetails {
             let is_elevated_output = Self::invoke_command(executor, "id", args.as_slice());
             let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
             let is_service_output =
-                Self::invoke_command(executor, "launchctl print openbas.agent", args.as_slice());
-            let is_service = Self::decode_output(&is_service_output.unwrap().clone().stderr);
+                Self::invoke_command(executor, "launchctl print openbas.agent.session", args.as_slice());
+            let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);
             Ok(ExecutionDetails {
                 is_elevated: is_elevated.contains("(admin)"),
-                is_service: is_service.contains("openbas.agent"),
+                is_service: !is_service.contains("openbas.agent.session"),
                 executed_by_user: user,
             })
         }

--- a/src/config/execution_details.rs
+++ b/src/config/execution_details.rs
@@ -115,7 +115,7 @@ impl ExecutionDetails {
             let is_elevated_output = Self::invoke_command(executor, "id", args.as_slice());
             let is_elevated = Self::decode_output(&is_elevated_output.unwrap().clone().stdout);
             let is_service_output =
-                Self::invoke_command(executor, "launchctl print openbas.agent.session", args.as_slice());
+                Self::invoke_command(executor, "launchctl print gui/$(id -u)/openbas.agent.session", args.as_slice());
             let is_service = Self::decode_output(&is_service_output.unwrap().clone().stdout);
             Ok(ExecutionDetails {
                 is_elevated: is_elevated.contains("(admin)"),


### PR DESCRIPTION
### Proposed changes

* Adding 4 new scripts installation and upgrade scripts for service user and session user agents
![image](https://github.com/user-attachments/assets/37f7f5ef-ba90-4220-a1c9-e8fa60eb7e06)

###Testing process

- Run your backend/front from release/current openbas
- For testing, download the scripts (installer and upgrade) locally on the machine you want to run the agent on
- Replace the different values ${OPENBAS_URL}/${OPENBAS_TOKEN}/${OPENBAS_UNSECURED_CERTIFICATE}"/${OPENBAS_WITH_PROXY}
- for the session installer script execute: sh agent-installer-service-user.sh
- for the session upgrade script execute: sh agent-upgrade-service-user.sh
- for the service installer: sudo sh agent-installer-service-user.sh --user [user] --group  [group]
- for the service upgrade: sh agent-upgrade-service-user.sh 

### Related issues

* #1860

### Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug
